### PR TITLE
V1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Usage:
 * Add a ```GDSAM``` node to your scene.
 * Call the ```speak(text)``` function to speak or ```speak2D(text, position)``` to speak positionally.
 * Call ```interrupt()``` to interrupt any queued phrases.
+* Subscribe to the ```buffer_loaded(buffer, callback)``` signal to grab the buffered speech data and provide your own audio stream before it is played.
 * Play with the ```speed```, ```pitch```, ```mouth``` and ```throat``` settings to modify the voice. Experiment!
 * Some stock voices are included based on the original demo.
   * ```set_voice_default()```

--- a/addons/gdsam/plugin.cfg
+++ b/addons/gdsam/plugin.cfg
@@ -3,5 +3,5 @@
 name="GDSAM"
 description="GDSAM provides retro voice synth capabilities via a wrapper library for SAM, the Software Automatic Mouth. Based on the C port by Sebastian Macke at https://github.com/s-macke/SAM."
 author="deadpixelsociety"
-version="1.1"
+version="1.2"
 script="plugin.gd"


### PR DESCRIPTION
#2 Added a new signal to the GDSAM node called `buffer_loaded` that will allow you to grab the buffer coming from the native portion, do with it what you'd like, and alternatively provide your own audio stream to playback.

Example usage:
```
func _on_gdsam_loaded_buffer(buffer, callback):
	var stream = AudioStreamSample.new()
	stream.data = buffer
	var pitched = AudioStreamRandomPitch.new()
	pitched.audio_stream = stream
	callback.audio_stream_override = pitched
```